### PR TITLE
disable case sensitivity

### DIFF
--- a/backup-export/src/main/java/com/opsgenie/tools/backup/ExportMain.java
+++ b/backup-export/src/main/java/com/opsgenie/tools/backup/ExportMain.java
@@ -20,6 +20,7 @@ public class ExportMain {
         CommandLineArgs commandLineArgs = new CommandLineArgs();
         final JCommander argumentParser = new JCommander(commandLineArgs);
         argumentParser.setProgramName("OpsGenieConfigExporter");
+        argumentParser.setCaseSensitiveOptions(false);
         try {
             argumentParser.parse(args);
         } catch (Exception e) {


### PR DESCRIPTION
Because `--apikey` vs `--apiKey` is a subtle distinction to enforce, I believe the user experience with this tool is better without case sensitivity.