### PR TITLE
Bugfix/issue#43 Schedule time restrictions have unstable list order across runs

### DIFF
--- a/backup-commons/build.gradle
+++ b/backup-commons/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'java'
 apply plugin: 'maven'
 
 group 'com.opsgenie.tools'
-version '0.23.3'
+version '0.23.4'
 
 sourceCompatibility = 1.6
 targetCompatibility = 1.6

--- a/backup-commons/src/main/java/com/opsgenie/tools/backup/retrieval/ScheduleRetriever.java
+++ b/backup-commons/src/main/java/com/opsgenie/tools/backup/retrieval/ScheduleRetriever.java
@@ -42,6 +42,8 @@ public class ScheduleRetriever implements EntityRetriever<ScheduleConfig> {
             }
         });
 
+        sortScheduleTimeRestrictions(schedules);
+
         for (Schedule schedule : schedules) {
             ScheduleConfig scheduleConfig = new ScheduleConfig();
             scheduleConfig.setSchedule(schedule);
@@ -54,6 +56,43 @@ public class ScheduleRetriever implements EntityRetriever<ScheduleConfig> {
         }
         return scheduleConfigs;
 
+    }
+
+    private void sortScheduleTimeRestrictions(List<Schedule> schedules) {
+        for(Schedule schedule: schedules) {
+            for(ScheduleRotation scheduleRotation: schedule.getRotations()) {
+                if(scheduleRotation.getTimeRestriction() instanceof WeekdayTimeRestrictionInterval) {
+                    WeekdayTimeRestrictionInterval weekdayTimeRestrictionInterval = (WeekdayTimeRestrictionInterval) scheduleRotation.getTimeRestriction();
+                    List<WeekdayTimeRestriction> restrictions = weekdayTimeRestrictionInterval.getRestrictions();
+                    Collections.sort(restrictions, new Comparator<WeekdayTimeRestriction>() {
+                        @Override
+                        public int compare(WeekdayTimeRestriction o1, WeekdayTimeRestriction o2) {
+                            return compareWeekdayTimeRestriction(o1, o2);
+                        }
+                    });
+                }
+            }
+        }
+    }
+
+    private int compareWeekdayTimeRestriction(WeekdayTimeRestriction o1, WeekdayTimeRestriction o2) {
+        int r = o1.getStartDay().compareTo(o2.getStartDay());
+        if(r != 0) return r;
+
+        r = o1.getStartHour().compareTo(o2.getStartHour());
+        if(r != 0) return r;
+
+        r = o1.getStartMin().compareTo(o2.getStartMin());
+        if(r != 0) return r;
+
+        r = o1.getEndDay().compareTo(o2.getEndDay());
+        if(r != 0) return r;
+
+        r = o1.getEndHour().compareTo(o2.getEndHour());
+        if(r != 0) return r;
+
+        r = o1.getEndMin().compareTo(o2.getEndMin());
+        return r;
     }
 
     private void sortScheduleOverrides(List<ScheduleOverride> scheduleOverrides) {

--- a/backup-export/build.gradle
+++ b/backup-export/build.gradle
@@ -1,5 +1,5 @@
 group 'com.opsgenie.tools'
-version '0.23.3'
+version '0.23.4'
 
 apply plugin: 'java'
 

--- a/backup-import/build.gradle
+++ b/backup-import/build.gradle
@@ -1,5 +1,5 @@
 group 'com.opsgenie.tools'
-version '0.23.3'
+version '0.23.4'
 
 apply plugin: 'java'
 

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'java'
 apply plugin: 'maven'
 
 group 'com.opsgenie.tools'
-version '0.23.3'
+version '0.23.4'
 
 sourceCompatibility = 1.6
 targetCompatibility = 1.6


### PR DESCRIPTION
### Why?

See Issue https://github.com/opsgenie/opsgenie-configuration-backup/issues/43

### What and How?

In the response returned by `GET` `/v2/schedules` API relative ordering of restrictions (for week day time type of time restriction) for a rotation in a schedule is unstable / non-deterministic across runs.

Fix this by sorting the restrictions in configuration backup tool.