### PR TITLE
Fix for Support for behind web proxy #39

### DIFF
--- a/backup-commons/build.gradle
+++ b/backup-commons/build.gradle
@@ -17,9 +17,9 @@ apply plugin: 'java'
 apply plugin: 'project-report'
 
 dependencies {
-    compile 'org.apache.logging.log4j:log4j-api:2.16.0'
-    compile 'org.apache.logging.log4j:log4j-core:2.16.0'
-    compile "org.apache.logging.log4j:log4j-slf4j-impl:2.16.0"
+    compile 'org.apache.logging.log4j:log4j-api:2.17.2'
+    compile 'org.apache.logging.log4j:log4j-core:2.17.2'
+    compile "org.apache.logging.log4j:log4j-slf4j-impl:2.17.2"
     compile "com.beust:jcommander:1.48"
     compile 'org.eclipse.jgit:org.eclipse.jgit:4.5.0.201609210915-r'
     compile "com.opsgenie.oas:opsgenie-sdk-swagger:1.0.10"

--- a/backup-commons/build.gradle
+++ b/backup-commons/build.gradle
@@ -4,8 +4,8 @@ apply plugin: 'maven'
 group 'com.opsgenie.tools'
 version '0.23.7'
 
-sourceCompatibility = 1.6
-targetCompatibility = 1.6
+sourceCompatibility = 1.8
+targetCompatibility = 1.8
 
 repositories {
     mavenLocal()
@@ -21,7 +21,12 @@ dependencies {
     compile 'org.apache.logging.log4j:log4j-core:2.17.2'
     compile "org.apache.logging.log4j:log4j-slf4j-impl:2.17.2"
     compile "com.beust:jcommander:1.48"
-    compile 'org.eclipse.jgit:org.eclipse.jgit:4.5.0.201609210915-r'
+    compile 'org.apache.httpcomponents:httpclient:4.5.13'
+    compile 'org.apache.httpcomponents:httpcore:4.4.15'
+    //compile 'com.jcraft:jsch:0.1.55'
+    compile 'org.eclipse.jgit:org.eclipse.jgit:5.13.0.202109080827-r'
+    compile 'org.eclipse.jgit:org.eclipse.jgit.ssh.apache:5.13.0.202109080827-r'
+    compile 'org.eclipse.jgit:org.eclipse.jgit.ssh.jsch:5.13.0.202109080827-r'
     compile "com.opsgenie.oas:opsgenie-sdk-swagger:1.0.10"
     compile ('com.fasterxml.jackson.core:jackson-databind:2.10.4') {
         force = true

--- a/backup-commons/src/main/java/com/opsgenie/tools/backup/BaseBackup.java
+++ b/backup-commons/src/main/java/com/opsgenie/tools/backup/BaseBackup.java
@@ -17,6 +17,10 @@ import org.eclipse.jgit.util.FS;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.eclipse.jgit.transport.JschConfigSessionFactory;
+import org.eclipse.jgit.transport.OpenSshConfig;
+import org.eclipse.jgit.transport.CredentialsProviderUserInfo;
+
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.UnsupportedEncodingException;

--- a/backup-commons/src/main/java/com/opsgenie/tools/backup/retry/RateLimitManager.java
+++ b/backup-commons/src/main/java/com/opsgenie/tools/backup/retry/RateLimitManager.java
@@ -26,7 +26,7 @@ public class RateLimitManager {
                 resultLimit = domainLimitDto.getLimit();
             }
         }
-        return resultLimit;
+        return Math.max(resultLimit, 1);
     }
 
     public int getRateLimit(DomainNames domain, int period) {

--- a/backup-commons/src/main/java/com/opsgenie/tools/backup/util/BackupUtils.java
+++ b/backup-commons/src/main/java/com/opsgenie/tools/backup/util/BackupUtils.java
@@ -49,7 +49,7 @@ public class BackupUtils {
 
     public static RateLimitsDto generateRateLimits(String apiKey, String opsGenieHost) throws IOException {
         try {
-            HttpClient client = HttpClientBuilder.create().build();
+            HttpClient client = HttpClientBuilder.create().useSystemProperties().build();
 
             HttpGet httpGet = new HttpGet(opsGenieHost + "/v2/request-limits/");
             httpGet.addHeader(HttpHeaders.AUTHORIZATION, "GenieKey " + apiKey);

--- a/backup-export/build.gradle
+++ b/backup-export/build.gradle
@@ -3,7 +3,7 @@ version '0.23.7'
 
 apply plugin: 'java'
 
-sourceCompatibility = 1.6
+sourceCompatibility = 1.8
 
 dependencies {
     compile project(':backup-commons')

--- a/backup-import/build.gradle
+++ b/backup-import/build.gradle
@@ -3,7 +3,7 @@ version '0.23.7'
 
 apply plugin: 'java'
 
-sourceCompatibility = 1.6
+sourceCompatibility = 1.8
 
 dependencies {
     compile project(':backup-commons')

--- a/build.gradle
+++ b/build.gradle
@@ -4,8 +4,8 @@ apply plugin: 'maven'
 group 'com.opsgenie.tools'
 version '0.23.7'
 
-sourceCompatibility = 1.6
-targetCompatibility = 1.6
+sourceCompatibility = 1.8
+targetCompatibility = 1.8
 
 repositories {
     mavenLocal()


### PR DESCRIPTION
This RP addresses these issues:
-  Support for behind web proxy #39, The core of application already works fine behind proxy, but accessing rete-limit API does not respect JVM proxy setting
- Log4j version was upgraded to 2.17.2
- Source and Target version was upgraded to Java 1.8

- Last patch is workaround for faulty RateLimitManager.getApiLimitForDomain(...) returns 0 for threadCount and then following line:

        pool = Executors.newFixedThreadPool(threadCount);

throws IllegalArgumentException.