### PR TITLE
Team ID fix in Schedule and Policy importer

### DIFF
--- a/backup-commons/build.gradle
+++ b/backup-commons/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'java'
 apply plugin: 'maven'
 
 group 'com.opsgenie.tools'
-version '0.23.8'
+version '0.23.9'
 
 sourceCompatibility = 1.6
 targetCompatibility = 1.6

--- a/backup-commons/src/main/java/com/opsgenie/tools/backup/util/BackupUtils.java
+++ b/backup-commons/src/main/java/com/opsgenie/tools/backup/util/BackupUtils.java
@@ -46,20 +46,21 @@ public class BackupUtils {
 
         return sb.toString();
     }
-    public static String getTeamNameFromId(File teamsDirectory, String teamId) {
+    public static OptionalUtil<String> getTeamNameFromId(File teamsDirectory, String teamId) {
         String[] files = getFileListOf(teamsDirectory);
+        OptionalUtil<String> teamName = OptionalUtil.empty();
         if (files.length == 0) {
             logger.warn("Warning: {} is empty", teamsDirectory);
-            return null;
         }
-        String teamName = null;
-        for (String fileName : files) {
-            if(fileName.contains(teamId)){
-                String[] fileNameSplitArr = fileName.split("-");
-                if(fileNameSplitArr.length > 0){
-                    teamName = fileNameSplitArr[0];
+        else {
+            for (String fileName : files) {
+                if(fileName.contains(teamId)){
+                    String[] fileNameSplitArr = fileName.split("-");
+                    if(fileNameSplitArr.length > 0){
+                        teamName = OptionalUtil.of(fileNameSplitArr[0]);
+                    }
+                    break;
                 }
-                break;
             }
         }
         return teamName;

--- a/backup-commons/src/main/java/com/opsgenie/tools/backup/util/BackupUtils.java
+++ b/backup-commons/src/main/java/com/opsgenie/tools/backup/util/BackupUtils.java
@@ -18,6 +18,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.*;
 import java.text.SimpleDateFormat;
+import java.util.Arrays;
 import java.util.List;
 
 public class BackupUtils {
@@ -46,6 +47,20 @@ public class BackupUtils {
 
         return sb.toString();
     }
+    public static String getTeamNameFromId(File teamsDirectory, String teamId) {
+        String[] files = getFileListOf(teamsDirectory);
+        if (files == null || files.length == 0) {
+            logger.warn("Warning: {} is empty", teamsDirectory);
+            return null;
+        }
+        for (String fileName : files) {
+            if(fileName.contains(teamId)){
+                return Arrays.stream(fileName.split("-")).findFirst().orElseGet(null);
+            }
+        }
+        return null;
+    }
+
 
     public static RateLimitsDto generateRateLimits(String apiKey, String opsGenieHost) throws IOException {
         try {

--- a/backup-commons/src/main/java/com/opsgenie/tools/backup/util/BackupUtils.java
+++ b/backup-commons/src/main/java/com/opsgenie/tools/backup/util/BackupUtils.java
@@ -18,7 +18,6 @@ import org.slf4j.LoggerFactory;
 
 import java.io.*;
 import java.text.SimpleDateFormat;
-import java.util.Arrays;
 import java.util.List;
 
 public class BackupUtils {
@@ -49,16 +48,21 @@ public class BackupUtils {
     }
     public static String getTeamNameFromId(File teamsDirectory, String teamId) {
         String[] files = getFileListOf(teamsDirectory);
-        if (files == null || files.length == 0) {
+        if (files.length == 0) {
             logger.warn("Warning: {} is empty", teamsDirectory);
             return null;
         }
+        String teamName = null;
         for (String fileName : files) {
             if(fileName.contains(teamId)){
-                return Arrays.stream(fileName.split("-")).findFirst().orElseGet(null);
+                String[] fileNameSplitArr = fileName.split("-");
+                if(fileNameSplitArr.length > 0){
+                    teamName = fileNameSplitArr[0];
+                }
+                break;
             }
         }
-        return null;
+        return teamName;
     }
 
 
@@ -89,7 +93,7 @@ public class BackupUtils {
                 }
             });
         }
-        return null;
+        return new String[]{};
     }
 
     public static boolean checkValidString(String s) {

--- a/backup-commons/src/main/java/com/opsgenie/tools/backup/util/OptionalUtil.java
+++ b/backup-commons/src/main/java/com/opsgenie/tools/backup/util/OptionalUtil.java
@@ -1,0 +1,40 @@
+package com.opsgenie.tools.backup.util;
+
+public class OptionalUtil<T> {
+    private final T value;
+    private static final OptionalUtil<?> EMPTY = new OptionalUtil();
+
+    private OptionalUtil() {
+        this.value = null;
+    }
+
+    private OptionalUtil(T value) {
+        this.value = value;
+    }
+
+    public static<T> OptionalUtil<T> empty() {
+        return  (OptionalUtil<T>) EMPTY;
+    }
+
+    public static <T> OptionalUtil<T> of(T value) {
+        if (value == null) {
+            throw new NullPointerException("Value cannot be null");
+        }
+        return new OptionalUtil<T>(value);
+    }
+
+    public T get() {
+        if (value == null) {
+            throw new IllegalStateException("Value is not present");
+        }
+        return value;
+    }
+
+    public boolean isPresent() {
+        return value != null;
+    }
+
+    public T orElse(T defaultValue) {
+        return value != null ? value : defaultValue;
+    }
+}

--- a/backup-export/build.gradle
+++ b/backup-export/build.gradle
@@ -1,5 +1,5 @@
 group 'com.opsgenie.tools'
-version '0.23.8'
+version '0.23.9'
 
 apply plugin: 'java'
 

--- a/backup-import/build.gradle
+++ b/backup-import/build.gradle
@@ -1,5 +1,5 @@
 group 'com.opsgenie.tools'
-version '0.23.8'
+version '0.23.9'
 
 apply plugin: 'java'
 

--- a/backup-import/src/main/java/com/opsgenie/tools/backup/ConfigurationImporter.java
+++ b/backup-import/src/main/java/com/opsgenie/tools/backup/ConfigurationImporter.java
@@ -71,7 +71,7 @@ public class ConfigurationImporter extends BaseBackup {
         importers.add(new TeamTemplateImporter(rootPath, rateLimitManager, config.isAddNewTeams(), config.isUpdateExistingTeams()));
         importers.add(new ScheduleTemplateImporter(rootPath, config.isAddNewSchedules(), config.isUpdateExistingSchedules()));
         importers.add(new EscalationImporter(rootPath, config.isAddNewEscalations(), config.isUpdateExistingEscalations()));
-        importers.add(new ScheduleImporter(rootPath, config.isAddNewSchedules(), config.isUpdateExistingSchedules()));
+        importers.add(new ScheduleImporter(rootPath, rateLimitManager, config.isAddNewSchedules(), config.isUpdateExistingSchedules()));
         importers.add(new TeamImporter(rootPath, rateLimitManager, config.isAddNewTeams(), config.isUpdateExistingTeams()));
         importers.add(new UserForwardingImporter(rootPath, config.isAddNewUserForwarding(), config.isUpdateExistingUserForwarding()));
         importers.add(new DeprecatedPolicyImporter(rootPath, config.isAddNewPolicies(), config.isUpdateExistingPolicies()));

--- a/backup-import/src/main/java/com/opsgenie/tools/backup/importers/BaseImporter.java
+++ b/backup-import/src/main/java/com/opsgenie/tools/backup/importers/BaseImporter.java
@@ -17,6 +17,7 @@ import java.util.Map;
 abstract class BaseImporter<T> implements Importer {
     protected final Logger logger = LoggerFactory.getLogger(getClass());
     protected File importDirectory;
+    protected File backupRootDirectory;
     private boolean addEntityEnabled;
     private boolean updateEntityEnabled;
     protected static Map<String, String> oldTeamIdMap = new HashMap<String, String>();
@@ -25,6 +26,7 @@ abstract class BaseImporter<T> implements Importer {
     BaseImporter(String backupRootDirectory, boolean addEntityEnabled, boolean updateEntityEnabled) {
         this.addEntityEnabled = addEntityEnabled;
         this.updateEntityEnabled = updateEntityEnabled;
+        this.backupRootDirectory = new File(backupRootDirectory + "/");
         this.importDirectory = new File(backupRootDirectory + "/" + getImportDirectoryName() + "/");
     }
 

--- a/backup-import/src/main/java/com/opsgenie/tools/backup/importers/BaseImporter.java
+++ b/backup-import/src/main/java/com/opsgenie/tools/backup/importers/BaseImporter.java
@@ -44,7 +44,7 @@ abstract class BaseImporter<T> implements Importer {
         }
 
         String[] files = BackupUtils.getFileListOf(importDirectory);
-        if (files == null || files.length == 0) {
+        if (files.length == 0) {
             logger.warn("Warning: " + getImportDirectoryName() + " is empty. Restoring " + getImportDirectoryName() + " skipped");
             return;
         }

--- a/backup-import/src/main/java/com/opsgenie/tools/backup/importers/PolicyImporter.java
+++ b/backup-import/src/main/java/com/opsgenie/tools/backup/importers/PolicyImporter.java
@@ -14,6 +14,7 @@ import com.opsgenie.tools.backup.retry.RateLimitManager;
 import com.opsgenie.tools.backup.retry.RetryPolicyAdapter;
 import com.opsgenie.tools.backup.util.BackupUtils;
 
+import java.io.File;
 import java.io.IOException;
 import java.text.SimpleDateFormat;
 import java.util.*;
@@ -148,8 +149,15 @@ public class PolicyImporter extends BaseImporter<PolicyWithTeamInfo> {
             if(entity.getPolicy().getClass() == AlertPolicy.class) {
                 AlertPolicy alertPolicy = (AlertPolicy) entity.getPolicy();
                 for(Responder responder : alertPolicy.getResponders()) {
-                    if(responder.getId().equals(entity.getTeamId())) {
-                        responder.setId(teamIdMap.get(teamName));
+                    if(responder.getType() == Responder.TypeEnum.TEAM) {
+                        File teamsDirectory = new File(backupRootDirectory + "/teams/");
+                        String responderTeamName = BackupUtils.getTeamNameFromId(teamsDirectory, responder.getId());
+                        if (responderTeamName != null){
+                            responder.setId(teamIdMap.get(responderTeamName));
+                        }
+                        else {
+                            logger.info("Could not find team name for team Id {} in the backup folder", responder.getId());
+                        }
                     }
                 }
             }

--- a/backup-import/src/main/java/com/opsgenie/tools/backup/importers/PolicyImporter.java
+++ b/backup-import/src/main/java/com/opsgenie/tools/backup/importers/PolicyImporter.java
@@ -13,7 +13,7 @@ import com.opsgenie.tools.backup.retrieval.PolicyRetriever;
 import com.opsgenie.tools.backup.retry.RateLimitManager;
 import com.opsgenie.tools.backup.retry.RetryPolicyAdapter;
 import com.opsgenie.tools.backup.util.BackupUtils;
-import org.eclipse.jgit.util.StringUtils;
+import com.opsgenie.tools.backup.util.OptionalUtil;
 
 import java.io.File;
 import java.io.IOException;
@@ -152,9 +152,9 @@ public class PolicyImporter extends BaseImporter<PolicyWithTeamInfo> {
                 for(Responder responder : alertPolicy.getResponders()) {
                     if(responder.getType() == Responder.TypeEnum.TEAM) {
                         File teamsDirectory = new File(backupRootDirectory + "/teams/");
-                        String responderTeamName = BackupUtils.getTeamNameFromId(teamsDirectory, responder.getId());
-                        if (!StringUtils.isEmptyOrNull(responderTeamName)){
-                            responder.setId(teamIdMap.get(responderTeamName));
+                        OptionalUtil<String> responderTeamName = BackupUtils.getTeamNameFromId(teamsDirectory, responder.getId());
+                        if (responderTeamName.isPresent()){
+                            responder.setId(teamIdMap.get(responderTeamName.get()));
                         }
                         else {
                             logger.info("Could not find team name for team Id {} in the backup folder", responder.getId());

--- a/backup-import/src/main/java/com/opsgenie/tools/backup/importers/PolicyImporter.java
+++ b/backup-import/src/main/java/com/opsgenie/tools/backup/importers/PolicyImporter.java
@@ -13,6 +13,7 @@ import com.opsgenie.tools.backup.retrieval.PolicyRetriever;
 import com.opsgenie.tools.backup.retry.RateLimitManager;
 import com.opsgenie.tools.backup.retry.RetryPolicyAdapter;
 import com.opsgenie.tools.backup.util.BackupUtils;
+import org.eclipse.jgit.util.StringUtils;
 
 import java.io.File;
 import java.io.IOException;
@@ -152,7 +153,7 @@ public class PolicyImporter extends BaseImporter<PolicyWithTeamInfo> {
                     if(responder.getType() == Responder.TypeEnum.TEAM) {
                         File teamsDirectory = new File(backupRootDirectory + "/teams/");
                         String responderTeamName = BackupUtils.getTeamNameFromId(teamsDirectory, responder.getId());
-                        if (responderTeamName != null){
+                        if (!StringUtils.isEmptyOrNull(responderTeamName)){
                             responder.setId(teamIdMap.get(responderTeamName));
                         }
                         else {

--- a/backup-import/src/main/java/com/opsgenie/tools/backup/importers/ScheduleImporter.java
+++ b/backup-import/src/main/java/com/opsgenie/tools/backup/importers/ScheduleImporter.java
@@ -209,11 +209,13 @@ public class ScheduleImporter extends BaseImporterWithRateLimiting<ScheduleConfi
     @Override
     protected void updateTeamIds(ScheduleConfig entity) throws Exception {
         Map<String, String> teamIdMap = new TeamIdMapper(rateLimitManager).getTeamIdMap();
-        TeamMeta ownerTeam = entity.getSchedule().getOwnerTeam();
-        if(ownerTeam != null){
-            String newTeamId = teamIdMap.get(ownerTeam.getName());
-            if(newTeamId != null) {
-                ownerTeam.setId(newTeamId);
+        if(entity.getSchedule() != null){
+            TeamMeta ownerTeam = entity.getSchedule().getOwnerTeam();
+            if(ownerTeam != null){
+                String newTeamId = teamIdMap.get(ownerTeam.getName());
+                if(newTeamId != null) {
+                    ownerTeam.setId(newTeamId);
+                }
             }
         }
     }

--- a/backup-import/src/main/java/com/opsgenie/tools/backup/importers/ScheduleImporter.java
+++ b/backup-import/src/main/java/com/opsgenie/tools/backup/importers/ScheduleImporter.java
@@ -8,20 +8,22 @@ import com.opsgenie.tools.backup.dto.ScheduleConfig;
 import com.opsgenie.tools.backup.retrieval.EntityRetriever;
 import com.opsgenie.tools.backup.retrieval.ScheduleRetriever;
 import com.opsgenie.tools.backup.retry.RetryPolicyAdapter;
+import com.opsgenie.tools.backup.retry.RateLimitManager;
 import com.opsgenie.tools.backup.util.BackupUtils;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.Callable;
 
-public class ScheduleImporter extends BaseImporter<ScheduleConfig> {
+public class ScheduleImporter extends BaseImporterWithRateLimiting<ScheduleConfig> {
 
     private static ScheduleApi scheduleApi = new ScheduleApi();
     private static ScheduleOverrideApi overrideApi = new ScheduleOverrideApi();
 
-    public ScheduleImporter(String backupRootDirectory, boolean addEntity, boolean updateEntitiy) {
-        super(backupRootDirectory, addEntity, updateEntitiy);
+    public ScheduleImporter(String backupRootDirectory, RateLimitManager rateLimitManager, boolean addEntity, boolean updateEntitiy) {
+        super(backupRootDirectory, rateLimitManager, addEntity, updateEntitiy);
     }
 
     @Override
@@ -205,5 +207,14 @@ public class ScheduleImporter extends BaseImporter<ScheduleConfig> {
     }
 
     @Override
-    protected void updateTeamIds(ScheduleConfig entity) {}
+    protected void updateTeamIds(ScheduleConfig entity) throws Exception {
+        Map<String, String> teamIdMap = new TeamIdMapper(rateLimitManager).getTeamIdMap();
+        TeamMeta ownerTeam = entity.getSchedule().getOwnerTeam();
+        if(ownerTeam != null){
+            String newTeamId = teamIdMap.get(ownerTeam.getName());
+            if(newTeamId != null) {
+                ownerTeam.setId(newTeamId);
+            }
+        }
+    }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'java'
 apply plugin: 'maven'
 
 group 'com.opsgenie.tools'
-version '0.23.8'
+version '0.23.9'
 
 sourceCompatibility = 1.6
 targetCompatibility = 1.6


### PR DESCRIPTION
This fixes the following issues during import - 

- Updating the schedule with rotation information. Currently it throws the error - `Error at updating Schedule Group A_schedule.{"message":"Team with 'id' [{old teamId}] does not exist"}`
- Adding a alert policy having a responder team which is different from owner team. Currently it throws the error - `Error at adding Policy route to team b. {"message":"Responder does not exist with id:{old teamId}"}
`